### PR TITLE
Fix issue with reading from synced file in a sharepoint folder

### DIFF
--- a/Excel_Adapter/CRUD/Read/Read.cs
+++ b/Excel_Adapter/CRUD/Read/Read.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.Excel
             XLWorkbook workbook = null;
             try
             {
-                FileStream fileStream = new FileStream(m_FileSettings.GetFullFileName(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                FileStream fileStream = new FileStream(m_FileSettings.GetFullFileName(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
                 workbook = new XLWorkbook(fileStream);
                 fileStream.Close();
             }


### PR DESCRIPTION
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #20

<!-- Add short description of what has been fixed -->

Adding `FileShare.Delete` to the `FileShare` enum when constructing the filestream. Fixes issues of unable to access file when trying to read from a file in a synced Sharepoint folder.

### Test files
<!-- Link to test files to validate the proposed changes -->

1. Sync a Shaprepoint folder with an excel file
2. Open the file
3. Read from the file


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->