### PR TITLE
Fix issue when pulling from cells with some types of formulas is them

### DIFF
--- a/Excel_Adapter/CRUD/Read/Read.cs
+++ b/Excel_Adapter/CRUD/Read/Read.cs
@@ -126,7 +126,7 @@ namespace BH.Adapter.Excel
                 foreach (IXLRangeColumn column in ixlRange.Columns())
                 {
                     if (valuesOnly)
-                        dataRow.Add(ixlWorksheet.Cell(row.RowNumber(), column.ColumnNumber()).GetValue<object>());
+                        dataRow.Add(ixlWorksheet.Cell(row.RowNumber(), column.ColumnNumber()).CellValueOrCashedValue());
                     else
                         dataRow.Add((ixlWorksheet.Cell(row.RowNumber(), column.ColumnNumber())).FromExcel());
                 }

--- a/Excel_Adapter/CRUD/Read/Read.cs
+++ b/Excel_Adapter/CRUD/Read/Read.cs
@@ -126,7 +126,7 @@ namespace BH.Adapter.Excel
                 foreach (IXLRangeColumn column in ixlRange.Columns())
                 {
                     if (valuesOnly)
-                        dataRow.Add(ixlWorksheet.Cell(row.RowNumber(), column.ColumnNumber()).CellValueOrCashedValue());
+                        dataRow.Add(ixlWorksheet.Cell(row.RowNumber(), column.ColumnNumber()).CellValueOrCachedValue());
                     else
                         dataRow.Add((ixlWorksheet.Cell(row.RowNumber(), column.ColumnNumber())).FromExcel());
                 }

--- a/Excel_Adapter/Convert/FromExcel/CellContents.cs
+++ b/Excel_Adapter/Convert/FromExcel/CellContents.cs
@@ -45,7 +45,7 @@ namespace BH.Adapter.Excel
             return new CellContents()
             {
                 Comment = xLCell.HasComment ? xLCell.Comment.Text : "",
-                Value = xLCell.Value,
+                Value = xLCell.CellValueOrCashedValue(),
                 Address = BH.Engine.Excel.Create.CellAddress(xLCell.Address.ToString()),
                 DataType = xLCell.DataType.SystemType(),
                 FormulaA1 = xLCell.FormulaA1,
@@ -53,8 +53,26 @@ namespace BH.Adapter.Excel
                 HyperLink = xLCell.HasHyperlink ? xLCell.Hyperlink.ExternalAddress.ToString() : "",
                 RichText = xLCell.HasRichText ? xLCell.RichText.Text : ""
             };
+
+
         }
 
+        /*******************************************/
+
+        public static object CellValueOrCashedValue(this IXLCell xLCell) 
+        {
+            object value;
+            if (!xLCell.TryGetValue(out value)) 
+            {
+                //If not able to just get the value, then get the cached value
+                //If cell is flagged as needing recalculation, raise warning.
+                if (xLCell.NeedsRecalculation)
+                    BH.Engine.Base.Compute.RecordWarning($"Cell {xLCell?.Address?.ToString() ?? "unknown"} is flagged as needing to be recalculated, but this is not able to be done. The cached value for this cell is returned, which for most cases is correct, but please ensure the validity of the value.");
+
+                value = xLCell.CachedValue;
+            }
+            return value;
+        }
 
         /*******************************************/
         /**** Private Methods                   ****/

--- a/Excel_Adapter/Convert/FromExcel/CellContents.cs
+++ b/Excel_Adapter/Convert/FromExcel/CellContents.cs
@@ -45,7 +45,7 @@ namespace BH.Adapter.Excel
             return new CellContents()
             {
                 Comment = xLCell.HasComment ? xLCell.Comment.Text : "",
-                Value = xLCell.CellValueOrCashedValue(),
+                Value = xLCell.CellValueOrCachedValue(),
                 Address = BH.Engine.Excel.Create.CellAddress(xLCell.Address.ToString()),
                 DataType = xLCell.DataType.SystemType(),
                 FormulaA1 = xLCell.FormulaA1,
@@ -62,7 +62,7 @@ namespace BH.Adapter.Excel
         [Description("Gets the value of the cell, or cached value if the TryGetValue method fails. Raises a warning if the cached value is used, and ClosedXML beleives the cell needs to be recalculated.")]
         [Input("xLCell", "IXLCell to get the (cached) value from.")]
         [Input("value", "Value or cached value of the cell.")]
-        public static object CellValueOrCashedValue(this IXLCell xLCell) 
+        public static object CellValueOrCachedValue(this IXLCell xLCell) 
         {
             object value;
             if (!xLCell.TryGetValue(out value)) 
@@ -70,7 +70,7 @@ namespace BH.Adapter.Excel
                 //If not able to just get the value, then get the cached value
                 //If cell is flagged as needing recalculation, raise warning.
                 if (xLCell.NeedsRecalculation)
-                    BH.Engine.Base.Compute.RecordWarning($"Cell {xLCell?.Address?.ToString() ?? "unknown"} is flagged as needing to be recalculated, but this is not able to be done. The cached value for this cell is returned, which for most cases is correct, but please ensure the validity of the value.");
+                    BH.Engine.Base.Compute.RecordWarning($"Cell {xLCell?.Address?.ToString() ?? "unknown"} is flagged as needing to be recalculated, but this is not able to be done. The cached value for this cell is returned, which for most cases is correct, but please check the validity of the value.");
 
                 value = xLCell.CachedValue;
             }

--- a/Excel_Adapter/Convert/FromExcel/CellContents.cs
+++ b/Excel_Adapter/Convert/FromExcel/CellContents.cs
@@ -59,6 +59,9 @@ namespace BH.Adapter.Excel
 
         /*******************************************/
 
+        [Description("Gets the value of the cell, or cached value if the TryGetValue method fails. Raises a warning if the cached value is used, and ClosedXML beleives the cell needs to be recalculated.")]
+        [Input("xLCell", "IXLCell to get the (cached) value from.")]
+        [Input("value", "Value or cached value of the cell.")]
         public static object CellValueOrCashedValue(this IXLCell xLCell) 
         {
             object value;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #22

<!-- Add short description of what has been fixed -->

As stated in the issue, there are some issues with reading values from some cells that contain some types of formulas.

The code in this PR fixes the issue by falling back to the cached value of the cell for when getting the Value out fails.
I went with raising a warning if this happens, and if closedXML believes the cell needs recalculation. For all cases I have tested so far, the cached value will be correct, but raised the warning to be safe.

Saying that, I was not aware that the adapter actually recomputed the sheet to get the values. Would have assumed that it just got whatever was in the cell, so might be safe to remove the warning.
Happy for any input on this from reviewers.


### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Excel_Toolkit/%2323-FixIssueReadingSheetsWithSomeTypesOfForumlas?csf=1&web=1&e=7dFRFj

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->