### PR TITLE
Updated Cell Range to Accept Numerical Only and Letter Only Inputs

### DIFF
--- a/Excel_Adapter/CRUD/Read/Read.cs
+++ b/Excel_Adapter/CRUD/Read/Read.cs
@@ -29,6 +29,7 @@ using BH.oM.Base;
 using BH.oM.Data.Collections;
 using BH.oM.Data.Requests;
 using ClosedXML.Excel;
+using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -91,6 +92,18 @@ namespace BH.Adapter.Excel
             string rangeString = "";
             if (range != null)
             {
+                if (string.IsNullOrEmpty(range.From.Column))
+                    range.From.Column = "A";
+
+                if(range.From.Row == -1)
+                    range.From.Row = 1;
+
+                if (string.IsNullOrEmpty(range.To.Column))
+                    range.To.Column = MaximumColumnName(workbook, worksheet);
+
+                if(range.To.Row == -1)
+                    range.To.Row = MaximumRowNumber(workbook, worksheet);
+
                 rangeString = range.ToExcel();
                 if (string.IsNullOrWhiteSpace(rangeString))
                     return new List<IBHoMObject>();
@@ -231,8 +244,45 @@ namespace BH.Adapter.Excel
             }).ToList<IBHoMObject>();
         }
 
+        /***************************************************/
+
+        private string MaximumColumnName(IXLWorkbook workbook, string worksheet)
+        {
+            var sheet = Worksheets(workbook, worksheet).FirstOrDefault();
+            if (sheet == null)
+                return "XFD"; //Maximum Excel Column name
+
+            var columnNumber = sheet.LastColumnUsed().ColumnNumber();
+            return ConvertToColumnName(columnNumber);     
+        }
 
         /***************************************************/
+
+        private int MaximumRowNumber(IXLWorkbook workbook, string worksheet)
+        {
+            var sheet = Worksheets(workbook, worksheet).FirstOrDefault();
+            if (sheet == null)
+                return 1048576; //Maximum Excel Row number
+
+            return sheet.LastRowUsed().RowNumber();
+        }
+
+        /***************************************************/
+
+        private string ConvertToColumnName(int number)
+        {
+            int mod = 0;
+            string columnHeading = "";
+
+            while (number > 0)
+            {
+                mod = (number - 1) % 26;
+                columnHeading = System.Convert.ToChar(65 + mod).ToString() + columnHeading;
+                number = (int)((number - mod) / 26);
+            }
+
+            return columnHeading;
+        }
     }
 }
 

--- a/Excel_Adapter/CRUD/Read/Read.cs
+++ b/Excel_Adapter/CRUD/Read/Read.cs
@@ -29,7 +29,6 @@ using BH.oM.Base;
 using BH.oM.Data.Collections;
 using BH.oM.Data.Requests;
 using ClosedXML.Excel;
-using DocumentFormat.OpenXml.Spreadsheet;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/Excel_Adapter/CRUD/Read/Read.cs
+++ b/Excel_Adapter/CRUD/Read/Read.cs
@@ -270,6 +270,7 @@ namespace BH.Adapter.Excel
 
         private string ConvertToColumnName(int number)
         {
+            //Taken from https://frasergreenroyd.com/convert-a-number-to-an-excel-column-heading/
             int mod = 0;
             string columnHeading = "";
 

--- a/Excel_Engine/Create/CellAddress.cs
+++ b/Excel_Engine/Create/CellAddress.cs
@@ -42,12 +42,19 @@ namespace BH.Engine.Excel
                 return null;
 
             string column = Regex.Match(excelAddress, @"[A-Z]+").Value;
-            int row = int.Parse(Regex.Match(excelAddress, @"\d+").Value);
+
+            int row = -1;
+            if(!m_LetterOnlyFormat.IsMatch(excelAddress))
+                row = int.Parse(Regex.Match(excelAddress, @"\d+").Value);
 
             return new CellAddress { Column = column, Row = row };
         }
 
         /*******************************************/
+        /**** Private fields                    ****/
+        /*******************************************/
+
+        private static readonly Regex m_LetterOnlyFormat = new Regex(@"^[A-Za-z]+$");
     }
 }
 

--- a/Excel_Engine/Create/CellRange.cs
+++ b/Excel_Engine/Create/CellRange.cs
@@ -23,6 +23,7 @@
 using BH.oM.Adapters.Excel;
 using BH.oM.Base.Attributes;
 using System.ComponentModel;
+using System.Text.RegularExpressions;
 
 namespace BH.Engine.Excel
 {
@@ -57,8 +58,6 @@ namespace BH.Engine.Excel
 
             return new CellRange { From = Create.CellAddress(from), To = Create.CellAddress(to) };
         }
-
-        /*******************************************/
     }
 }
 

--- a/Excel_Engine/Create/CellRange.cs
+++ b/Excel_Engine/Create/CellRange.cs
@@ -23,7 +23,6 @@
 using BH.oM.Adapters.Excel;
 using BH.oM.Base.Attributes;
 using System.ComponentModel;
-using System.Text.RegularExpressions;
 
 namespace BH.Engine.Excel
 {

--- a/Excel_Engine/Query/IsValid.cs
+++ b/Excel_Engine/Query/IsValid.cs
@@ -123,7 +123,7 @@ namespace BH.Engine.Excel
 
             if (split.Length != 2)
             {
-                BH.Engine.Base.Compute.RecordError("Must provided values in the format of 'expression1:expression2'");
+                BH.Engine.Base.Compute.RecordError("Range values must be in the format of 'expression1:expression2'");
                 return false;
             }
 

--- a/Excel_Engine/Query/IsValid.cs
+++ b/Excel_Engine/Query/IsValid.cs
@@ -96,7 +96,14 @@ namespace BH.Engine.Excel
                 return false;
             }
 
+            if(m_ColumnIndexFormat.IsMatch(address))
+            {
+                //Address is letters only, no numbers - skip number check
+                return true;
+            }
+
             int row = int.Parse(Regex.Match(address, @"\d+").Value);
+
             if (row < 1)
             {
                 BH.Engine.Base.Compute.RecordError($"Address equal to { address} is not valid: row index cannot lower than 1.");
@@ -153,7 +160,7 @@ namespace BH.Engine.Excel
         /*******************************************/
 
         private static readonly Regex m_ColumnIndexFormat = new Regex(@"^[A-Za-z]+$");
-        private static readonly Regex m_AddressFormat = new Regex(@"^[A-Za-z]+\d+$");
+        private static readonly Regex m_AddressFormat = new Regex(@"^([A-Za-z]*\d*)$");
         private static readonly Regex m_RangeFormat = new Regex(@"^([A-Za-z]*\d*):([A-Za-z]*\d*)$");
 
         /*******************************************/

--- a/Excel_Engine/Query/IsValid.cs
+++ b/Excel_Engine/Query/IsValid.cs
@@ -119,17 +119,32 @@ namespace BH.Engine.Excel
                 return false;
             }
 
-            if (!m_RangeFormat.IsMatch(range))
+            string[] split = range.Split(new char[] { ':' });
+
+            if (split.Length != 2)
             {
-                BH.Engine.Base.Compute.RecordError($"Range equal to {range} is not valid: it needs to consist of two sets of capital letters followed by digits, divided with a colon, for example 'A1:Z99'.");
+                BH.Engine.Base.Compute.RecordError("Must provided values in the format of 'expression1:expression2'");
                 return false;
             }
 
-            string[] split = range.Split(new char[] { ':' });
             string from = split[0];
             string to = split[1];
 
-            return from.IsValidAddress() && to.IsValidAddress();
+            Regex matchBegins0 = new Regex("^0$");
+
+            if (matchBegins0.IsMatch(from) || matchBegins0.IsMatch(to))
+            {
+                BH.Engine.Base.Compute.RecordError("Cell value cannot be or begin with 0.")
+                return false;
+            }
+
+            if (!m_RangeFormat.IsMatch(range))
+            {
+                BH.Engine.Base.Compute.RecordError($"Range equal to {range} is not valid: it needs to consist of two similar expressions separated by a colon, for example 'A1:Z99', 'A:B', or '3:9'.");
+                return false;
+            }
+
+            return true;
         }
 
 
@@ -137,9 +152,9 @@ namespace BH.Engine.Excel
         /**** Private fields                    ****/
         /*******************************************/
 
-        private static readonly Regex m_ColumnIndexFormat = new Regex(@"^[A-Z]+$");
-        private static readonly Regex m_AddressFormat = new Regex(@"^[A-Z]+\d+$");
-        private static readonly Regex m_RangeFormat = new Regex(@"^[A-Z]+\d+:[A-Z]+\d+$");
+        private static readonly Regex m_ColumnIndexFormat = new Regex(@"^[A-Za-z]+$");
+        private static readonly Regex m_AddressFormat = new Regex(@"^[A-Za-z]+\d+$");
+        private static readonly Regex m_RangeFormat = new Regex(@"^([A-Za-z]*\d*):([A-Za-z]*\d*)$");
 
         /*******************************************/
     }

--- a/Excel_Engine/Query/IsValid.cs
+++ b/Excel_Engine/Query/IsValid.cs
@@ -134,7 +134,7 @@ namespace BH.Engine.Excel
 
             if (matchBegins0.IsMatch(from) || matchBegins0.IsMatch(to))
             {
-                BH.Engine.Base.Compute.RecordError("Cell value cannot be or begin with 0.")
+                BH.Engine.Base.Compute.RecordError("Cell value cannot be or begin with 0.");
                 return false;
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #25 

<!-- Add short description of what has been fixed -->
-Updated IsValidRange to accept letters-only and numbers-only inputs in addition to standard cell addresses, for example A:A, 2:3.
-Also updated regular expressions for cell addresses and column addresses to be case insensitive.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->