### PR TITLE
Add ability to push multiple tables without reopening the file every time

### DIFF
--- a/Excel_Adapter/AdapterActions/Push.cs
+++ b/Excel_Adapter/AdapterActions/Push.cs
@@ -30,6 +30,7 @@ using ClosedXML.Excel;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Linq;
 
@@ -64,7 +65,7 @@ namespace BH.Adapter.Excel
 
             // Cast action config to ExcelPushConfig, create new if null.
             ExcelPushConfig config = actionConfig as ExcelPushConfig;
-            if (config == null)
+            if (config == null && !(objects.FirstOrDefault() is PushItem))
             {
                 BH.Engine.Base.Compute.RecordNote($"{nameof(ExcelPushConfig)} has not been provided, default config is used.");
                 config = new ExcelPushConfig();
@@ -91,6 +92,74 @@ namespace BH.Adapter.Excel
             {
                 BH.Engine.Base.Compute.RecordError("File settings or template stream have not been provided.");
                 return new List<object>();
+            }
+
+            // Push the objects
+            List<object> pushedObjects = new List<object>();
+            if (objects.FirstOrDefault() is PushItem)
+            {
+                foreach (PushItem item in objects.OfType<PushItem>())
+                {
+                    if (PushObjects(workbook, item.Objects, item.Config, pushType))
+                        pushedObjects.AddRange(item.Objects);
+                } 
+            }
+            else
+            {
+                if (PushObjects(workbook, objects.ToList(), config, pushType))
+                    pushedObjects = objects.ToList();
+            }
+                
+            // Try to update the workbook properties and then save it.
+            try
+            {
+                if (config != null)
+                    Update(workbook, config.WorkbookProperties);
+
+                if (m_FileSettings != null)
+                    workbook.SaveAs(m_FileSettings.GetFullFileName());
+                else if (m_OutputStream != null)
+                {
+                    workbook.SaveAs(m_OutputStream);
+                    m_OutputStream.Position = 0;
+                }  
+                else
+                {
+                    BH.Engine.Base.Compute.RecordError("Output stream has not been provided. The workbook cannot be saved.");
+                    return new List<object>();
+                }
+
+                return pushedObjects;
+            }
+            catch (Exception e)
+            {
+                BH.Engine.Base.Compute.RecordError($"Finalisation and saving of the workbook failed with the following error: {e.Message}");
+                return new List<object>();
+            }
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private bool PushObjects(XLWorkbook workbook, List<object> objects, ExcelPushConfig config, PushType pushType = PushType.AdapterDefault)
+        {
+            // Makwe sure the config is defined
+            if (config == null)
+            {
+                BH.Engine.Base.Compute.RecordNote($"{nameof(ExcelPushConfig)} has not been provided, default config is used.");
+                config = new ExcelPushConfig();
+            }
+
+            // Make sure that a single type of objects are pushed
+            List<Type> objectTypes = objects.Select(x => x.GetType()).Distinct().ToList();
+            if (objectTypes.Count != 1)
+            {
+                string message = "The Excel adapter only allows to push objects of a single type per table."
+                    + "\nRight now you are providing objects of the following types: "
+                    + objectTypes.Select(x => x.ToString()).Aggregate((a, b) => a + ", " + b);
+                Engine.Base.Compute.RecordError(message);
+                return false;
             }
 
             // Split the tables into collections to delete, create and update.
@@ -134,39 +203,14 @@ namespace BH.Adapter.Excel
                 default:
                     {
                         BH.Engine.Base.Compute.RecordError($"Currently Excel adapter does not supports {nameof(PushType)} equal to {pushType}");
-                        return new List<object>();
+                        return false;
                     }
             }
 
-            // Try to update the workbook properties and then save it.
-            try
-            {
-                Update(workbook, config.WorkbookProperties);
-
-                if (m_FileSettings != null)
-                    workbook.SaveAs(m_FileSettings.GetFullFileName());
-                else if (m_OutputStream != null)
-                {
-                    workbook.SaveAs(m_OutputStream);
-                    m_OutputStream.Position = 0;
-                }  
-                else
-                {
-                    BH.Engine.Base.Compute.RecordError("Output stream has not been provided. The workbook cannot be saved.");
-                    return new List<object>();
-                }
-
-                return success ? objects.ToList() : new List<object>();
-            }
-            catch (Exception e)
-            {
-                BH.Engine.Base.Compute.RecordError($"Finalisation and saving of the workbook failed with the following error: {e.Message}");
-                return new List<object>();
-            }
+            return success;
         }
 
-        /***************************************************/
-        /**** Private Methods                           ****/
+
         /***************************************************/
 
         private XLWorkbook CreateWorkbookFromFile(string fileName, PushType pushType)

--- a/Excel_oM/PushItem.cs
+++ b/Excel_oM/PushItem.cs
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+
+namespace BH.oM.Adapters.Excel
+{
+    public class PushItem : BHoMObject
+    {
+        public virtual List<object> Objects { get; set; } = new List<object>();
+
+        public virtual ExcelPushConfig Config { get; set; } = new ExcelPushConfig();
+    }
+}
+
+


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #53

### Test files

[EC_Report_SpeedTest.zip](https://github.com/BHoM/Excel_Toolkit/files/13872256/EC_Report_SpeedTest.zip)

This proves to be especially relevant when the Excel adapter is used by another toolkit to produce report. 
So, the best way to test this is via this PR: https://github.com/BuroHappoldEngineering/StructureEmbodiedCarbon_Toolkit/pull/31

I recommend to test the Excel PR first without the other one to make sure everything is still working when pushing one table at a time. Once that confirmed to be working, recompile the other repo using the PR and confirm that the component is still working and is faster. Personally, I got this computational time: 

![image](https://github.com/BHoM/Excel_Toolkit/assets/16853390/49b7adbf-2eaa-4ce1-a2e6-784ce1588b84)


