### PR TITLE
Remove unnecessary using which is preventing ZeroCodeTool build

### DIFF
--- a/Excel_Adapter/AdapterActions/Push.cs
+++ b/Excel_Adapter/AdapterActions/Push.cs
@@ -30,7 +30,6 @@ using ClosedXML.Excel;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
 using System.IO;
 using System.Linq;
 

--- a/altConfigs.txt
+++ b/altConfigs.txt
@@ -1,0 +1,1 @@
+BHoM/Excel_Toolkit/ZeroCodeTool


### PR DESCRIPTION
Fixes issue where ZeroCodeTool config cannot build for Nugets