### PR TITLE
Change target framework and remove no longer required dependencies

### DIFF
--- a/Excel_Adapter/ExcelAdapter.cs
+++ b/Excel_Adapter/ExcelAdapter.cs
@@ -86,10 +86,12 @@ namespace BH.Adapter.Excel
 
         private Assembly PackagingAssemblyResolve(object sender, ResolveEventArgs args)
         {
-            if (args.Name.StartsWith("System.IO.Packaging,"))
+            string[] split = args.Name.Split(',');
+            if (split.Length > 1)
             {
-                string assemblyPath = Path.Combine(BH.Engine.Base.Query.BHoMFolder(), "System.IO.Packaging.dll");
-                return Assembly.LoadFrom(assemblyPath);
+                string assemblyPath = Path.Combine(BH.Engine.Base.Query.BHoMFolder(), $"{split[0]}.dll");
+                if (File.Exists(assemblyPath))
+                    return Assembly.LoadFrom(assemblyPath);
             }
 
             return null;

--- a/Excel_Adapter/ExcelAdapter.cs
+++ b/Excel_Adapter/ExcelAdapter.cs
@@ -27,8 +27,6 @@ using BH.oM.Data.Requests;
 using System.ComponentModel;
 using System.IO;
 using System.Reflection;
-using System.Security;
-using System.Security.Policy;
 using System.Threading;
 
 namespace BH.Adapter.Excel
@@ -57,10 +55,6 @@ namespace BH.Adapter.Excel
             }
 
             m_FileSettings = fileSettings;
-
-            // This is needed because of save action of large files being made with an isolated storage 
-            // Fox taken from http://rekiwi.blogspot.com/2008/12/unable-to-determine-identity-of-domain.html
-            VerifySecurityEvidenceForIsolatedStorage(this.GetType().Assembly);
         }
 
         /***************************************************/
@@ -93,45 +87,6 @@ namespace BH.Adapter.Excel
             }
             else
                 return base.SetupPullRequest(request, out actualRequest);
-        }
-
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        private void VerifySecurityEvidenceForIsolatedStorage(Assembly assembly)
-        {
-            var isEvidenceFound = true;
-#if ZCTDEPLOY
-            var initialAppDomainEvidence = new Evidence();
-#else
-            var initialAppDomainEvidence = System.Threading.Thread.GetDomain().Evidence;
-#endif
-
-            try
-            {
-                // this will fail when the current AppDomain Evidence is instantiated via COM or in PowerShell
-                using (var usfdAttempt1 = System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForDomain())
-                {
-                }
-            }
-            catch (System.IO.IsolatedStorage.IsolatedStorageException e)
-            {
-                isEvidenceFound = false;
-            }
-
-            if (!isEvidenceFound)
-            {
-                initialAppDomainEvidence.AddHostEvidence(new Url(assembly.Location));
-                initialAppDomainEvidence.AddHostEvidence(new Zone(SecurityZone.MyComputer));
-
-                var currentAppDomain = Thread.GetDomain();
-                var securityIdentityField = currentAppDomain.GetType().GetField("_SecurityIdentity", BindingFlags.Instance | BindingFlags.NonPublic);
-                securityIdentityField.SetValue(currentAppDomain, initialAppDomainEvidence);
-
-                //var latestAppDomainEvidence = System.Threading.Thread.GetDomain().Evidence; // setting a breakpoint here will let you inspect the current app domain evidence
-            }
         }
 
 

--- a/Excel_Adapter/ExcelAdapter.cs
+++ b/Excel_Adapter/ExcelAdapter.cs
@@ -27,6 +27,7 @@ using BH.oM.Data.Requests;
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 
@@ -43,8 +44,6 @@ namespace BH.Adapter.Excel
         [Output("adapter", "Adapter to Excel.")]
         public ExcelAdapter(BH.oM.Adapter.FileSettings fileSettings = null)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(PackagingAssemblyResolve);
-
             if (fileSettings == null)
             {
                 BH.Engine.Base.Compute.RecordError("Please set the File Settings to enable the Excel Adapter to work correctly.");
@@ -67,8 +66,6 @@ namespace BH.Adapter.Excel
         [Output("outputStream", "Defines the content of the new Excel file. This will be generated on a push and is not required for a pull.")]
         public ExcelAdapter(Stream inputStream, Stream outputStream = null)
         {
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(PackagingAssemblyResolve);
-
             if (inputStream == null)
             {
                 BH.Engine.Base.Compute.RecordError("Please set the Stream for the template to enable the Excel Adapter to work correctly.");
@@ -77,24 +74,6 @@ namespace BH.Adapter.Excel
 
             m_InputStream = inputStream;
             m_OutputStream = outputStream;
-        }
-
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        private Assembly PackagingAssemblyResolve(object sender, ResolveEventArgs args)
-        {
-            string[] split = args.Name.Split(',');
-            if (split.Length > 1)
-            {
-                string assemblyPath = Path.Combine(BH.Engine.Base.Query.BHoMFolder(), $"{split[0]}.dll");
-                if (File.Exists(assemblyPath))
-                    return Assembly.LoadFrom(assemblyPath);
-            }
-
-            return null;
         }
 
 

--- a/Excel_Adapter/ExcelAdapter.cs
+++ b/Excel_Adapter/ExcelAdapter.cs
@@ -24,6 +24,7 @@ using BH.Adapter;
 using BH.oM.Adapters.Excel;
 using BH.oM.Base.Attributes;
 using BH.oM.Data.Requests;
+using System;
 using System.ComponentModel;
 using System.IO;
 using System.Reflection;
@@ -42,6 +43,8 @@ namespace BH.Adapter.Excel
         [Output("adapter", "Adapter to Excel.")]
         public ExcelAdapter(BH.oM.Adapter.FileSettings fileSettings = null)
         {
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(PackagingAssemblyResolve);
+
             if (fileSettings == null)
             {
                 BH.Engine.Base.Compute.RecordError("Please set the File Settings to enable the Excel Adapter to work correctly.");
@@ -64,6 +67,8 @@ namespace BH.Adapter.Excel
         [Output("outputStream", "Defines the content of the new Excel file. This will be generated on a push and is not required for a pull.")]
         public ExcelAdapter(Stream inputStream, Stream outputStream = null)
         {
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(PackagingAssemblyResolve);
+
             if (inputStream == null)
             {
                 BH.Engine.Base.Compute.RecordError("Please set the Stream for the template to enable the Excel Adapter to work correctly.");
@@ -73,6 +78,23 @@ namespace BH.Adapter.Excel
             m_InputStream = inputStream;
             m_OutputStream = outputStream;
         }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private Assembly PackagingAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            if (args.Name.StartsWith("System.IO.Packaging,"))
+            {
+                string assemblyPath = Path.Combine(BH.Engine.Base.Query.BHoMFolder(), "System.IO.Packaging.dll");
+                return Assembly.LoadFrom(assemblyPath);
+            }
+
+            return null;
+        }
+
 
         /***************************************************/
         /**** Override Methods                          ****/

--- a/Excel_Adapter/Excel_Adapter.csproj
+++ b/Excel_Adapter/Excel_Adapter.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+	<TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <Description>https://github.com/BHoM/Excel_Toolkit</Description>
     <Version>5.0.0</Version>
@@ -13,14 +14,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <TargetFramework>net472</TargetFramework>
-    <DefineConstants>INSTALLERDEPLOY</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>ZCTDEPLOY</DefineConstants>
-  </PropertyGroup>
+
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
     <Exec Command="xcopy &quot;$(TargetPath)&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /C /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ClosedXML.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ExcelNumberFormat.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)SixLabors.Fonts.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.IO.Packaging.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)Irony.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)XLParser.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
@@ -70,15 +64,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
@@ -88,8 +74,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-    <PackageReference Include="System.Security.AccessControl" Version="6.0.2-mauipre.1.22102.15" />
-    <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">

--- a/Excel_Adapter/Excel_Adapter.csproj
+++ b/Excel_Adapter/Excel_Adapter.csproj
@@ -62,25 +62,15 @@
       <HintPath>$(ProgramData)\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
     </Reference>
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
 
   <ItemGroup>
+	<Reference Include="Microsoft.CSharp" />
     <PackageReference Include="ClosedXML" Version="0.102.2" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
     <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
   </ItemGroup>
 

--- a/Excel_Engine/Excel_Engine.csproj
+++ b/Excel_Engine/Excel_Engine.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+	<TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <Description>https://github.com/BHoM/Excel_Toolkit</Description>
     <Version>5.0.0</Version>
@@ -11,15 +12,6 @@
     <Configurations>Debug;Release;ZeroCodeTool</Configurations>
     <OutputPath>..\Build\</OutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <TargetFramework>net472</TargetFramework>
-    <DefineConstants>INSTALLERDEPLOY</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>ZCTDEPLOY</DefineConstants>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
@@ -46,17 +38,6 @@
       <HintPath>$(ProgramData)\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
 
 </Project>

--- a/Excel_Toolkit.sln
+++ b/Excel_Toolkit.sln
@@ -13,27 +13,20 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		ZeroCodeTool|Any CPU = ZeroCodeTool|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{79D1BABE-DF98-4635-A605-AA396FF58915}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{79D1BABE-DF98-4635-A605-AA396FF58915}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79D1BABE-DF98-4635-A605-AA396FF58915}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79D1BABE-DF98-4635-A605-AA396FF58915}.Release|Any CPU.Build.0 = Release|Any CPU
-		{79D1BABE-DF98-4635-A605-AA396FF58915}.ZeroCodeTool|Any CPU.ActiveCfg = ZeroCodeTool|Any CPU
-		{79D1BABE-DF98-4635-A605-AA396FF58915}.ZeroCodeTool|Any CPU.Build.0 = ZeroCodeTool|Any CPU
 		{A6884466-297E-4AAA-A232-ABBEC42168D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A6884466-297E-4AAA-A232-ABBEC42168D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A6884466-297E-4AAA-A232-ABBEC42168D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A6884466-297E-4AAA-A232-ABBEC42168D3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A6884466-297E-4AAA-A232-ABBEC42168D3}.ZeroCodeTool|Any CPU.ActiveCfg = ZeroCodeTool|Any CPU
-		{A6884466-297E-4AAA-A232-ABBEC42168D3}.ZeroCodeTool|Any CPU.Build.0 = ZeroCodeTool|Any CPU
 		{79FAC4B0-77EC-4257-BCBE-CFF37FFF537C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{79FAC4B0-77EC-4257-BCBE-CFF37FFF537C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79FAC4B0-77EC-4257-BCBE-CFF37FFF537C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79FAC4B0-77EC-4257-BCBE-CFF37FFF537C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{79FAC4B0-77EC-4257-BCBE-CFF37FFF537C}.ZeroCodeTool|Any CPU.ActiveCfg = ZeroCodeTool|Any CPU
-		{79FAC4B0-77EC-4257-BCBE-CFF37FFF537C}.ZeroCodeTool|Any CPU.Build.0 = ZeroCodeTool|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Excel_oM/Excel_oM.csproj
+++ b/Excel_oM/Excel_oM.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+	<TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>8.0.0.0</AssemblyVersion>
     <Description>https://github.com/BHoM/Excel_Toolkit</Description>
     <Version>5.0.0</Version>
@@ -11,15 +12,6 @@
     <Configurations>Debug;Release;ZeroCodeTool</Configurations>
     <OutputPath>..\Build\</OutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <TargetFramework>net472</TargetFramework>
-    <DefineConstants>INSTALLERDEPLOY</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)'=='ZeroCodeTool'">
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>ZCTDEPLOY</DefineConstants>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
@@ -42,17 +34,6 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="WindowsBase" />
   </ItemGroup>
 
 </Project>

--- a/altConfigs.txt
+++ b/altConfigs.txt
@@ -1,1 +1,0 @@
-BHoM/Excel_Toolkit/ZeroCodeTool


### PR DESCRIPTION
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM_Engine/pull/3453

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #79

<!-- Add short description of what has been fixed -->

Changes the target framework of the debug and release build to simply be netstandard2.0 . 

Whilst attempting to do this, realised that the reason this toolkit was still on 4.7.2 net framework was the `VerifySecurityEvidenceForIsolatedStorage` to handle saving of large files. From testing with file provided in https://github.com/BHoM/Excel_UI/pull/331 this does not seem to be an issue any longer for netstandard2.0 , hence the method has been removed.

@pawelbaran would greatly appreciate if you are able to check that you are happy with this removal, given you raised this and fixed it in the first place.

Ofc general functionality of the toolkit should also be checked to ensure this does not have any other detrimental impacts on the toolkit.

### Test files
<!-- Link to test files to validate the proposed changes -->

[Test file here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Excel_Toolkit/%2381-ChangeTargetFrameworkAndRemoveNoLongerRequiredDependencies?csf=1&web=1&e=KeYLfY)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->