### PR TITLE
Consolidate versions of external dependencies

### DIFF
--- a/.ci/BHoMBot/Nuget/BHoM.Interop.Excel.nuspec
+++ b/.ci/BHoMBot/Nuget/BHoM.Interop.Excel.nuspec
@@ -18,11 +18,10 @@
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.3" />
         <dependency id="Microsoft.CSharp" version="4.7.0" />
-        <dependency id="ClosedXML" version="0.102.2" />
-        <dependency id="DocumentFormat.OpenXml" version="2.16.0" />
+        <dependency id="ClosedXML" version="0.105.0" />
+        <dependency id="DocumentFormat.OpenXml" version="3.1.1" />
         <dependency id="ExcelNumberFormat" version="1.1.0" />
         <dependency id="SixLabors.Fonts" version="1.0.0" />
-        <dependency id="System.IO.Packaging" version="6.0.0" />
         <dependency id="System.Security.AccessControl" version="6.0.2-mauipre.1.22102.15" />
         <dependency id="System.Security.Permissions" version="8.0.0" />
       </group>

--- a/Excel_Adapter/Excel_Adapter.csproj
+++ b/Excel_Adapter/Excel_Adapter.csproj
@@ -17,7 +17,7 @@
 
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='Release'">
-    <Exec Command="xcopy &quot;$(TargetPath)&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /C /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ClosedXML.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ExcelNumberFormat.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)SixLabors.Fonts.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.IO.Packaging.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)Irony.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)XLParser.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="xcopy &quot;$(TargetPath)&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /C /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ClosedXML.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ExcelNumberFormat.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)DocumentFormat.OpenXml.Framework.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)ClosedXML.Parser.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)SixLabors.Fonts.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.IO.Packaging.dll&quot;  &quot;$(ProgramData)\BHoM\Assemblies&quot; /Y" />
   </Target>
 
   <ItemGroup>
@@ -65,12 +65,11 @@
 
   <ItemGroup>
 	<Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="ClosedXML" Version="0.102.2" />
-    <PackageReference Include="DocumentFormat.OpenXml" Version="2.16.0" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.1.1" />
     <PackageReference Include="ExcelNumberFormat" Version="1.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0" />
-    <PackageReference Include="System.IO.Packaging" Version="6.0.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #104

System.IO.Packaging 6.0.0 is vulnerable so we are now targeting version 8.0.1. This will be done indirectly by
- Upgrading ClosedXML to 0.105.5
- Upgrading DocumentFormat.OpenXml to 3.1.1
- Removing direct dependency to System.IO.Packaging

This is related to those PR and should be tested together:
- https://github.com/BHoM/SAP_Toolkit/pull/188
- https://github.com/BHoM/PowerPoint_Toolkit/pull/40

### Test files
Usual testing procedure


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->